### PR TITLE
fix: correct test assertion in ApplicationTest.php to match homepage template

### DIFF
--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -12,6 +12,6 @@ class ApplicationTest extends WebTestCase
         $crawler = $client->request('GET', '/');
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains('h1', 'Welcome to Your Survey Application');
+        $this->assertSelectorTextContains('h1', 'Welcome to Survey Application');
     }
 }


### PR DESCRIPTION
## Summary

Fixes a test assertion mismatch in `ApplicationTest.php` where the test expected "Welcome to Your Survey Application" but the actual homepage template displays "Welcome to Survey Application".

### Changes
- Updated test assertion in `tests/ApplicationTest.php:15` to remove the word "Your" from the expected text
- Changed from `'Welcome to Your Survey Application'` to `'Welcome to Survey Application'`

### Testing
- Verified the fix matches the actual template content in `templates/home/index.html.twig:9`
- The assertion now correctly matches the h1 element text in the homepage

### Related Issue
Closes #58

🤖 Generated with [Claude Code](https://claude.ai/code)