### PR TITLE
fix: resolve unit test heading mismatch (#180)

### DIFF
--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -12,6 +12,6 @@ class ApplicationTest extends WebTestCase
         $crawler = $client->request('GET', '/');
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorTextContains('h1', 'Welcome to Your Survey Application');
+        $this->assertSelectorTextContains('h1', 'Welcome to Survey Application');
     }
 }


### PR DESCRIPTION
## Summary
Fixed the failing unit test by updating the test assertion to match the actual template content and consistent branding pattern used throughout the application.

## Changes
- Updated test assertion in `tests/ApplicationTest.php:15`
- Changed from "Welcome to Your Survey Application" to "Welcome to Survey Application"
- Aligns with consistent branding used in navbar, footer, page titles, and throughout the application

## Testing
- Test assertion now matches the actual template content in `templates/home/index.html.twig:9`
- Fix addresses the failing CI/CD pipeline mentioned in issue #180

## Related Issue
Closes #180

🤖 Generated with [Claude Code](https://claude.ai/code)